### PR TITLE
Move "babel-plugin-rewire" into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "bin"
   ],
   "dependencies": {
-    "babel-plugin-rewire": "^1.0.0-rc-3",
     "babel-runtime": "^6.3.19",
     "follow-redirects": "0.0.7",
     "lodash": "^4.2.0",
@@ -45,6 +44,7 @@
     "axios": "^0.9.1",
     "babel-cli": "^6.4.5",
     "babel-eslint": "^5.0.0-beta8",
+    "babel-plugin-rewire": "^1.0.0-rc-3",
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.4.3",


### PR DESCRIPTION
As far as I can tell, `babel-plugin-rewire` isn't required as a production dependency.

At the moment I have to include the following dependencies in _my_ package.json to satisfy `babel-plugin-rewire`'s peer dependency requirements:

- `babel-core`
- `babel-template`
- `babel-types`

This pull request moves the plugin into `devDependencies`.