### PR TITLE
fix(ratelimit): only retry on 500

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -12,8 +12,7 @@ export default function rateLimit (instance, maxRetry = 10) {
     // in axios reponse will be available only if there a response from server
     // in this case will assume it is a 500 error
     error.response = error.response || {status: 500}
-
-    if (error.response.status >= 500) {
+    if (error.response.status === 500) {
       attempt++
       lastErrorAt = lastErrorAt || Date.now()
       if (Date.now() - lastErrorAt >= 30000) {
@@ -28,7 +27,7 @@ export default function rateLimit (instance, maxRetry = 10) {
     }
 
     // retry if we receive 429 or 500
-    if (error.response.status === 429 || error.response.status >= 500) {
+    if (error.response.status === 429 || error.response.status === 500) {
       var rateLimitHeaderValue = 0
       // all headers are lowercased by axios https://github.com/mzabriskie/axios/issues/413
       if (error.response.headers && error.response.headers['x-contentful-rateLimit-reset']) {


### PR DESCRIPTION
To avoid retrying when the user gives a wrong token or space id we should only retry on 500 errors