### PR TITLE
Chore/house keeping

### DIFF
--- a/bin/test-ci.sh
+++ b/bin/test-ci.sh
@@ -9,7 +9,7 @@ set -e
 if ./node_modules/contentful-sdk-core/bin/run-if-node-version.js ; then
   npm run test:cover
 else
-  npm run test:only
+  npm run test:unit
 fi
 
 # Create the CommonJS and browser builds, so we can run integration tests using those

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-node": "^5.1.0",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-standard": "^3.0.1",
-    "husky": "^0.13.1",
+    "husky": "^0.14.3",
     "in-publish": "^2.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "test": "npm run test:cover",
     "test:ci": "npm run test:cover",
     "test:ci-emulate": "trevor",
-    "test:cover": "BABEL_ENV=test babel-node ./node_modules/istanbul/lib/cli.js cover test/runner",
-    "test:only": "BABEL_ENV=test babel-node ./test/runner",
+    "test:cover": "BABEL_ENV=test babel-node ./node_modules/istanbul/lib/cli.js cover ./test/runner | tap-spec",
+    "test:unit": "BABEL_ENV=test babel-node ./test/runner | tap-spec",
     "test:debug": "BABEL_ENV=test babel-node debug ./test/runner",
     "browser-coverage": "npm run test:cover && opener coverage/lcov-report/index.html",
     "prepublish": "in-publish && npm run build || not-in-publish",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "precommit": "npm run lint",
-    "prepush": "npm run test:only"
+    "prepush": "npm run test:unit"
   },
   "files": [
     "dist",
@@ -77,6 +77,7 @@
     "rimraf": "^2.5.1",
     "semantic-release": "^6.3.2",
     "sinon": "^2.0.0-pre",
+    "tap-spec": "^4.1.1",
     "trevor": "^2.3.0"
   },
   "config": {


### PR DESCRIPTION
introduces tab-spec for proper test output +  some minor dependency upgrades

Also, renames unit tests from `only` to `unit`. That confused me for a while.

Needed by https://github.com/contentful/contentful.js/pull/172 && https://github.com/contentful/contentful-management.js/pull/122 to pass tests.