### PR TITLE
refactor(user-agent): simplify node detection

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -2,6 +2,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import qs from 'qs'
 
 import rateLimit from './rate-limit'
+import { isNode, getNodeVersion } from './get-user-agent'
 
 // Matches 'sub.host:port' and extracts hostname and port
 // Also enforces toplevel domain specified, no spaces and no protocol
@@ -82,8 +83,8 @@ export default function createHttpClient (axios, options) {
   // Set these headers only for node because browsers don't like it when you
   // override user-agent or accept-encoding.
   // The SDKs should set their own X-Contentful-User-Agent.
-  if (process && process.release && process.release.name === 'node') {
-    config.headers['user-agent'] = 'node.js/' + process.version
+  if (isNode()) {
+    config.headers['user-agent'] = 'node.js/' + getNodeVersion()
     config.headers['Accept-Encoding'] = 'gzip'
   }
 

--- a/lib/get-user-agent.js
+++ b/lib/get-user-agent.js
@@ -4,8 +4,12 @@ function isReactNative () {
   return typeof window !== 'undefined' && 'navigator' in window && 'product' in window.navigator && window.navigator.product === 'ReactNative'
 }
 
-function isNode () {
-  return typeof process !== 'undefined' && 'release' in process && 'name' in process.release
+export function isNode () {
+  return typeof process !== 'undefined'
+}
+
+export function getNodeVersion () {
+  return process.versions.node ? `v${process.versions.node}` : process.version
 }
 
 function getBrowserOS () {
@@ -72,7 +76,7 @@ export default function getUserAgentHeader (sdk, application, integration) {
     headerParts.push('platform ReactNative')
   } else if (isNode()) {
     os = getNodeOS()
-    headerParts.push(`platform node.js/${process.versions.node}`)
+    headerParts.push(`platform node.js/${getNodeVersion()}`)
   } else {
     os = getBrowserOS()
     headerParts.push(`platform browser`)

--- a/test/unit/user-agent-test.js
+++ b/test/unit/user-agent-test.js
@@ -7,6 +7,7 @@ test('Parse node user agent correctly', (t) => {
   const userAgent = getUserAgent('contentful.js/1.0.0', 'myApplication/1.0.0', 'myIntegration/1.0.0')
   t.equal(userAgent.match(headerRegEx).length, 5, 'consists of 5 parts')
   t.true(userAgent.indexOf('platform node.js/') !== -1, 'detects node.js platform')
+  t.true(userAgent.match(/node\.js\/\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\b/), 'detected valid semver node version')
   t.end()
 })
 


### PR DESCRIPTION
In N|Solid environments `process.release.name === 'node'` is false since the value is `nsolid`.

Since webpack checks simply for `process` to be present, I switched to this logic.