### PR TITLE
fix(retry): do only retry axios related errors

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -7,16 +7,17 @@ export default function rateLimit (instance, maxRetry = 5) {
     return response
   }, function (error) {
     let { response, config } = error
-    if (!instance.defaults.retryOnError) {
+
+    // Do not retry if it is disabled or no request config exists (not an axios error)
+    if (!config || !instance.defaults.retryOnError) {
       return Promise.reject(error)
     }
 
     let retryErrorType = null
     let wait = 0
 
-    // Errors without response or config did not recieve anything from the server
-    // Should be a network related error
-    if (!response || !config) {
+    // Errors without response did not recieve anything from the server
+    if (!response) {
       retryErrorType = 'Connection'
       networkErrorAttempts++
 


### PR DESCRIPTION
fixes #49 

My assumption when implementing connection error retries was faulty.

I assumed that errors with no config + no response are always connection errors. I checked [axios-retry](https://github.com/softonic/axios-retry/blob/master/es/index.js#L177-L180) and the new logic will now skip the retry when no config is available.

That way we match axios-retry more closely and easy up the way to migrating to the plugin later on.