### PR TITLE
fix: return empty os for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "index.js",
   "module": "index.es-modules.js",
   "jsnext:main": "index.es-modules.js",
+  "browser": {
+    "os": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/contentful/contentful-sdk-core.git"


### PR DESCRIPTION
This PR fixes the issues https://github.com/contentful/contentful.js/issues/243 without having to bundle all the modules for browser builds as done as with PR https://github.com/contentful/contentful.js/pull/247 and https://github.com/contentful/contentful-management.js/pull/171 which had the following side effect https://github.com/contentful/contentful.js/issues/260.

All this PR does is "For browser build I don't need the os package. Give me an empty one."

Please create a release tag after the merge then we can update the dependency in  https://github.com/contentful/contentful.js and https://github.com/contentful/contentful-management.js and then remove the browser field.