### PR TITLE
fix(rate-limit): don't throw in setTimeout cb

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -55,15 +55,15 @@ export default function rateLimit (instance, maxRetry = 5) {
       }
     }
 
+    const delay = ms => new Promise((resolve) => {
+      setTimeout(resolve, ms)
+    })
+
     if (retryErrorType) {
       // convert to ms and add jitter
       wait = Math.floor(wait * 1000 + (Math.random() * 200) + 500)
       instance.defaults.logHandler('warning', `${retryErrorType} error occurred. Waiting for ${wait} ms before retrying...`)
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(instance(config))
-        }, wait)
-      })
+      return delay(wait).then(() => instance(config))
     }
     return Promise.reject(error)
   })


### PR DESCRIPTION
Currently, if when `setTimeout` triggers, the call of `instance(config)` throws, the thrown exception can't be caught. Separating the `delay` logic into its own function so the callback is invoked inside a `.then` means a rejected Promise is returned and can be handled, instead.