### PR TITLE
Allow setting a custom adapter

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -97,6 +97,7 @@ export default function createHttpClient (axios, options) {
     paramsSerializer: qs.stringify,
     proxy: config.proxy,
     timeout: config.timeout,
+    adapter: config.adapter,
     // Contentful
     logHandler: config.logHandler,
     retryOnError: config.retryOnError

--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -19,6 +19,7 @@ const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.[^\s:]+)(?::(\d+))?(?!:)$/
  * @prop {string=} host - Alternate host
  * @prop {Object=} httpAgent - HTTP agent for node
  * @prop {Object=} httpsAgent - HTTPS agent for node
+ * @prop {function=} adapter - Axios adapter to handle requests
  * @prop {Object=} proxy - Axios proxy config
  * @prop {Object=} headers - Additional headers
  * @prop {function=} logHandler - A log handler function to process given log messages & errors. Receives the log level (error, warning & info) and the actual log data (Error object or string). (Default can be found here: https://github.com/contentful/contentful-sdk-core/blob/master/lib/create-http-client.js)
@@ -43,7 +44,8 @@ export default function createHttpClient (axios, options) {
     httpsAgent: false,
     timeout: 30000,
     proxy: false,
-    basePath: ''
+    basePath: '',
+    adapter: false
   }
   const config = {
     ...defaultConfig,


### PR DESCRIPTION
This will need a corresponding update on the contentful.js library but lays the groundwork for setting a custom adapter.
Such as [patrickhousley/ngx-axios-adapter](https://github.com/patrickhousley/ngx-axios-adapter) to allow the usa of the contenful sdk in an angular universal situation