### PR TITLE
Do not overwrite the Authorization header

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -82,7 +82,9 @@ export default function createHttpClient (axios, options) {
 
   const baseURL = options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
 
-  config.headers['Authorization'] = 'Bearer ' + config.accessToken
+  if (!config.headers['Authorization']) {
+    config.headers['Authorization'] = 'Bearer ' + config.accessToken
+  }
 
   // Set these headers only for node because browsers don't like it when you
   // override user-agent or accept-encoding.

--- a/test/unit/create-http-client-test.js
+++ b/test/unit/create-http-client-test.js
@@ -82,6 +82,23 @@ test('Calls axios based on passed hostname with insecure flag', t => {
   t.end()
 })
 
+test('Calls axios based on passed headers', t => {
+  setup()
+  createHttpClient(axios, {
+    accessToken: 'clientAccessToken',
+    headers: {
+      'X-Custom-Header': 'example',
+      Authorization: 'Basic customAuth'
+    }
+  })
+
+  t.equals(axios.create.args[0][0].headers['X-Custom-Header'], 'example')
+  t.equals(axios.create.args[0][0].headers['Authorization'], 'Basic customAuth')
+
+  teardown()
+  t.end()
+})
+
 test('Calls axios with reques/response logger', t => {
   setup()
   createHttpClient(axios, {


### PR DESCRIPTION
At Intercom, we've built a simple proxy (using NGINX) to allow our devs to access the `GET /spaces/:id/environments/:id/content_types` endpoint without needing a CMA access token.

We're using the CMA for this because it exposes validation information, which we need for our TypeScript codegen.

We have basic auth set up on the proxy server, but I was a little surprised to find that my custom `Authorization` header was being overwritten when creating the `contentful-management` client.

This is a simple change which prevents the `Authorization` header from being overwritten if it's already set. It'd be great if this could get merged and incorporated into `contentful-management` so that we could use it without forking. 😄 