### PR TITLE
fix(rate-limit): do not overwrite httpAgent on retries

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -75,6 +75,13 @@ export default function rateLimit (instance, defaults, maxRetry = 5) {
       // convert to ms and add jitter
       wait = Math.floor(wait * 1000 + (Math.random() * 200) + 500)
       instanceDefaults.logHandler('warning', `${retryErrorType} error occurred. Waiting for ${wait} ms before retrying...`)
+
+      /* Somehow between the interceptor and retrying the request the httpAgent/httpsAgent gets transformed from an Agent-like object
+         to a regular object, causing failures on retries after rate limits. Removing these properties here fixes the error, but retry
+         requests still use the original http/httpsAgent property */
+      delete config.httpAgent
+      delete config.httpsAgent
+
       return delay(wait).then(() => instance(config))
     }
     return Promise.reject(error)


### PR DESCRIPTION
There is a bug somewhere between our sdk-core and axios that causes agent objects to be flattened from "Agent-like objects" to regular objects on retried requests, causing an error for some enterprise users that use proxies and custom httpAgents.

I spent a day's effort trying to track down the bug, with no success. This fixes the error and retried requests eventually succeed (still using the originally configured httpAgents). I confirmed this with a test script that causes rate limit errors and a local proxy.