### PR TITLE
Add configurable max content length for Axios

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -47,7 +47,8 @@ export default function createHttpClient (axios, options) {
     timeout: 30000,
     proxy: false,
     basePath: '',
-    adapter: false
+    adapter: false,
+    maxContentLength: 1073741824 // 1GB
   }
   const config = {
     ...defaultConfig,
@@ -104,6 +105,7 @@ export default function createHttpClient (axios, options) {
     proxy: config.proxy,
     timeout: config.timeout,
     adapter: config.adapter,
+    maxContentLength: config.maxContentLength,
     // Contentful
     logHandler: config.logHandler,
     responseLogger: config.responseLogger,


### PR DESCRIPTION
This PR allows users to upload files of up to 1 GB and also allows them also to configure the maximum content length.