### PR TITLE
fix(getNodeVersion): Safety check before accessing process.versions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,5 +10,5 @@ export function isNode () {
 }
 
 export function getNodeVersion () {
-  return process.versions.node ? `v${process.versions.node}` : process.version
+  return process.versions && process.versions.node ? `v${process.versions.node}` : process.version
 }


### PR DESCRIPTION
Fixes #82 (partially)