### PR TITLE
Add support for `fetchOptions`

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -19,6 +19,7 @@ const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
  * @prop {string=} host - Alternate host
  * @prop {Object=} httpAgent - HTTP agent for node
  * @prop {Object=} httpsAgent - HTTPS agent for node
+ * @prop {Object=} fetchOptions - Options to apply when using the `fetch` adapter.
  * @prop {function=} adapter - Axios adapter to handle requests
  * @prop {function=} requestLogger - Gets called on every request triggered by the SDK, takes the axios request config as an argument
  * @prop {function=} responseLogger - Gets called on every response, takes axios response object as an argument
@@ -105,6 +106,7 @@ export default function createHttpClient (axios, options) {
     timeout: config.timeout,
     adapter: config.adapter,
     maxContentLength: config.maxContentLength,
+    fetchOptions: config.fetchOptions || {},
     // Contentful
     logHandler: config.logHandler,
     responseLogger: config.responseLogger,


### PR DESCRIPTION
This changeset adds support for a new upstream config parameter in Axios, `fetchOptions`, which applies various options when using the `fetch` adapter.

See PR contentful/contentful.js#396 for more info.