### PR TITLE
Fix linter errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/node,windows,osx,linux,vim
+
+.idea/

--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -82,8 +82,8 @@ export default function createHttpClient (axios, options) {
 
   const baseURL = options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
 
-  if (!config.headers['Authorization']) {
-    config.headers['Authorization'] = 'Bearer ' + config.accessToken
+  if (!config.headers.Authorization) {
+    config.headers.Authorization = 'Bearer ' + config.accessToken
   }
 
   // Set these headers only for node because browsers don't like it when you

--- a/lib/get-user-agent.js
+++ b/lib/get-user-agent.js
@@ -78,7 +78,7 @@ export default function getUserAgentHeader (sdk, application, integration, featu
       headerParts.push(`platform node.js/${getNodeVersion()}`)
     } else {
       os = getBrowserOS()
-      headerParts.push(`platform browser`)
+      headerParts.push('platform browser')
     }
   } catch (e) {
     os = null

--- a/test/unit/create-http-client-test.js
+++ b/test/unit/create-http-client-test.js
@@ -93,7 +93,7 @@ test('Calls axios based on passed headers', t => {
   })
 
   t.equals(axios.create.args[0][0].headers['X-Custom-Header'], 'example')
-  t.equals(axios.create.args[0][0].headers['Authorization'], 'Basic customAuth')
+  t.equals(axios.create.args[0][0].headers.Authorization, 'Basic customAuth')
 
   teardown()
   t.end()


### PR DESCRIPTION
While I did prepare for another PR, I've spotted some linter issues, which block running the unit tests.

The errors in detail:
```
➜  contentful-sdk-core git:(fix-linter-errors) ✗ npm run lint 

> contentful-sdk-core@0.0.1-determined-by-semantic-release lint ~/projects/contentful-sdk-core
> eslint lib test


~/projects/contentful-sdk-core/lib/create-http-client.js
  85:23  error  ["Authorization"] is better written in dot notation  dot-notation
  86:20  error  ["Authorization"] is better written in dot notation  dot-notation

~/projects/contentful-sdk-core/lib/get-user-agent.js
  81:24  error  Strings must use singlequote  quotes

~/projects/contentful-sdk-core/test/unit/create-http-client-test.js
  96:44  error  ["Authorization"] is better written in dot notation  dot-notation

✖ 4 problems (4 errors, 0 warnings)
  4 errors and 0 warnings potentially fixable with the `--fix` option.
```

I did apply the --fix option and this is the resulting PR.
I have to admit, it includes that IntelliJ project folder is excluded - I hope that's ok for you.
