### PR TITLE
fix(loggers): call reqLogger and resLogger in error cases

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -9,6 +9,7 @@ export default function rateLimit (instance, maxRetry = 5) {
     requestLogger(config)
     return config
   }, function (error) {
+    requestLogger(error)
     return Promise.reject(error)
   })
 
@@ -18,6 +19,7 @@ export default function rateLimit (instance, maxRetry = 5) {
     return response
   }, function (error) {
     let { response, config } = error
+    responseLogger(error)
     // Do not retry if it is disabled or no request config exists (not an axios error)
     if (!config || !instance.defaults.retryOnError) {
       return Promise.reject(error)


### PR DESCRIPTION
we should also call requestLogger and responseLogger in error cases, since this is one of the only way users can debug their SDK calls.