### PR TITLE
feat: remove lodash

### DIFF
--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -82,8 +82,8 @@ export default function createHttpClient (axios, options) {
 
   const baseURL = options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
 
-  if (!config.headers['Authorization']) {
-    config.headers['Authorization'] = 'Bearer ' + config.accessToken
+  if (!config.headers.Authorization) {
+    config.headers.Authorization = 'Bearer ' + config.accessToken
   }
 
   // Set these headers only for node because browsers don't like it when you

--- a/lib/create-http-client.js
+++ b/lib/create-http-client.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 import qs from 'qs'
 
 import rateLimit from './rate-limit'
@@ -126,7 +126,7 @@ export default function createHttpClient (axios, options) {
    */
   instance.cloneWithNewParams = function (newParams) {
     return createHttpClient(axios, {
-      ...cloneDeep(options),
+      ...copy(options),
       ...newParams
     })
   }

--- a/lib/create-request-config.js
+++ b/lib/create-request-config.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 /**
  * Creates request parameters configuration by parsing an existing query object
@@ -9,6 +9,6 @@ import cloneDeep from 'lodash/cloneDeep'
 export default function createRequestConfig ({ query }) {
   const config = {}
   delete query.resolveLinks
-  config.params = cloneDeep(query)
+  config.params = copy(query)
   return config
 }

--- a/lib/freeze-sys.js
+++ b/lib/freeze-sys.js
@@ -1,16 +1,20 @@
-import isPlainObject from 'lodash/isPlainObject'
+// copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
 
-function freezeObjectDeep (obj) {
-  Object.keys(obj).forEach((key) => {
-    const value = obj[key]
-    if (isPlainObject(value)) {
-      freezeObjectDeep(value)
+function deepFreeze (object) {
+  const propNames = Object.getOwnPropertyNames(object)
+
+  for (const name of propNames) {
+    const value = object[name]
+
+    if (value && typeof value === 'object') {
+      deepFreeze(value)
     }
-  })
-  return Object.freeze(obj)
+  }
+
+  return Object.freeze(object)
 }
 
 export default function freezeSys (obj) {
-  freezeObjectDeep(obj.sys || {})
+  deepFreeze(obj.sys || {})
   return obj
 }

--- a/lib/get-user-agent.js
+++ b/lib/get-user-agent.js
@@ -78,7 +78,7 @@ export default function getUserAgentHeader (sdk, application, integration, featu
       headerParts.push(`platform node.js/${getNodeVersion()}`)
     } else {
       os = getBrowserOS()
-      headerParts.push(`platform browser`)
+      headerParts.push('platform browser')
     }
   } catch (e) {
     os = null

--- a/lib/to-plain-object.js
+++ b/lib/to-plain-object.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 /**
  * Mixes in a method to return just a plain object with no additional methods
@@ -12,7 +12,7 @@ export default function toPlainObject (data) {
     configurable: false,
     writable: false,
     value: function () {
-      return cloneDeep(this)
+      return copy(this)
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "node": ">=6"
   },
   "dependencies": {
+    "fast-copy": "^2.1.0",
     "lodash": "^4.17.10",
     "qs": "^6.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "fast-copy": "^2.1.0",
-    "lodash": "^4.17.10",
     "qs": "^6.5.2"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,12 @@
-import pkg from './package.json';
-import babel from 'rollup-plugin-babel';
+import pkg from './package.json'
+import babel from 'rollup-plugin-babel'
 
 export default [
   {
     input: 'lib/index.js',
     output: [
       { file: pkg.module, format: 'esm' },
-      { file: pkg.main, format: 'cjs' },
+      { file: pkg.main, format: 'cjs' }
     ],
     plugins: [
       babel({
@@ -20,9 +20,7 @@ export default [
     ],
     external: [
       ...Object.keys(pkg.dependencies || []),
-      'os',
-      'lodash/isPlainObject',
-      'lodash/cloneDeep'
+      'os'
     ]
   }
-];
+]

--- a/test/unit/create-http-client-test.js
+++ b/test/unit/create-http-client-test.js
@@ -93,7 +93,7 @@ test('Calls axios based on passed headers', t => {
   })
 
   t.equals(axios.create.args[0][0].headers['X-Custom-Header'], 'example')
-  t.equals(axios.create.args[0][0].headers['Authorization'], 'Basic customAuth')
+  t.equals(axios.create.args[0][0].headers.Authorization, 'Basic customAuth')
 
   teardown()
   t.end()
@@ -168,7 +168,7 @@ test('Calls axios based on passed hostname with invalid basePath and fixes the i
 test('Can change the adapter axios uses', t => {
   const testAdapter = function myAdapter (config) {
     return new Promise(function (resolve, reject) {
-      var response = {
+      const response = {
         data: 'Adapter was used',
         status: 200,
         statusText: 'request.statusText',

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -1,4 +1,3 @@
-import assign from 'lodash/assign'
 import cloneDeep from 'lodash/cloneDeep'
 
 const linkMock = {
@@ -17,7 +16,7 @@ const sysMock = {
 }
 
 const contentTypeMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType'
   }),
   name: 'name',
@@ -35,9 +34,9 @@ const contentTypeMock = {
 }
 
 const entryMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'Entry',
-    contentType: assign(cloneDeep(linkMock), { linkType: 'ContentType' }),
+    contentType: Object.assign(cloneDeep(linkMock), { linkType: 'ContentType' }),
     locale: 'locale'
   }),
   fields: {
@@ -46,7 +45,7 @@ const entryMock = {
 }
 
 const assetMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'Asset',
     locale: 'locale'
   }),

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 const linkMock = {
   id: 'linkid',
@@ -9,14 +9,14 @@ const linkMock = {
 const sysMock = {
   type: 'Type',
   id: 'id',
-  space: cloneDeep(linkMock),
+  space: copy(linkMock),
   createdAt: 'createdatdate',
   updatedAt: 'updatedatdate',
   revision: 1
 }
 
 const contentTypeMock = {
-  sys: Object.assign(cloneDeep(sysMock), {
+  sys: Object.assign(copy(sysMock), {
     type: 'ContentType'
   }),
   name: 'name',
@@ -34,9 +34,9 @@ const contentTypeMock = {
 }
 
 const entryMock = {
-  sys: Object.assign(cloneDeep(sysMock), {
+  sys: Object.assign(copy(sysMock), {
     type: 'Entry',
-    contentType: Object.assign(cloneDeep(linkMock), { linkType: 'ContentType' }),
+    contentType: Object.assign(copy(linkMock), { linkType: 'ContentType' }),
     locale: 'locale'
   }),
   fields: {
@@ -45,7 +45,7 @@ const entryMock = {
 }
 
 const assetMock = {
-  sys: Object.assign(cloneDeep(sysMock), {
+  sys: Object.assign(copy(sysMock), {
     type: 'Asset',
     locale: 'locale'
   }),


### PR DESCRIPTION
One of the required steps to fix https://github.com/contentful/contentful.js/issues/408 by removing lodash entirely.
`cloneDeep` has been replaced by https://github.com/planttheidea/fast-copy and `isPlainObject` was made redundant by using a slightly changed `deepFreeze` implementation.