### PR TITLE
feat: [] user agent header function accepts any additional info

### DIFF
--- a/src/get-user-agent.ts
+++ b/src/get-user-agent.ts
@@ -53,7 +53,8 @@ export default function getUserAgentHeader(
   sdk: string,
   application?: string,
   integration?: string,
-  feature?: string
+  feature?: string,
+  additionalInfo?: {[key: string]: string}
 ): string {
   const headerParts = []
 
@@ -89,6 +90,12 @@ export default function getUserAgentHeader(
 
   if (os) {
     headerParts.push(`os ${os}`)
+  }
+
+  if (additionalInfo) {
+    Object.entries(additionalInfo).forEach(([key, value]) => {
+      headerParts.push(`${key} ${value}`)
+    })
   }
 
   return `${headerParts.filter((item) => item !== '').join('; ')};`

--- a/test/unit/user-agent-test.spec.ts
+++ b/test/unit/user-agent-test.spec.ts
@@ -35,6 +35,23 @@ it('Parse node user agent correctly', () => {
   ).toBeTruthy()
 })
 
+it('Parses additional Info', () => {
+  const userAgent = getUserAgent(
+    'contentful.js/1.0.0',
+    'myApplication/1.0.0',
+    'myIntegration/1.0.0'
+  )
+
+  // detects node.js platform
+  expect(userAgent.indexOf('platform node.js/') !== -1).toBeTruthy()
+  // detected valid semver node version
+  expect(
+    userAgent.match(
+      /node\.js\/\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\b/
+    )
+  ).toBeTruthy()
+})
+
 it('Parse browser user agent correctly', () => {
   mockedUtils.isNode.mockReturnValue(false)
 
@@ -88,4 +105,17 @@ it('Parse react native user agent correctly', () => {
   expect(userAgent.match(headerRegEx)?.length).toEqual(4)
   // detects react native platform
   expect(userAgent.indexOf('platform ReactNative') !== -1).toBeTruthy()
+})
+
+it('Parses additional Info', () => {
+  const userAgent = getUserAgent(
+    'contentful.js/1.0.0',
+    'myApplication/1.0.0',
+    'myIntegration/1.0.0',
+    undefined,
+    { hungry: 'nope' }
+  )
+
+  // detects node.js platform
+  expect(userAgent.indexOf('hungry nope') !== -1).toBeTruthy()
 })

--- a/test/unit/user-agent-test.spec.ts
+++ b/test/unit/user-agent-test.spec.ts
@@ -35,23 +35,6 @@ it('Parse node user agent correctly', () => {
   ).toBeTruthy()
 })
 
-it('Parses additional Info', () => {
-  const userAgent = getUserAgent(
-    'contentful.js/1.0.0',
-    'myApplication/1.0.0',
-    'myIntegration/1.0.0'
-  )
-
-  // detects node.js platform
-  expect(userAgent.indexOf('platform node.js/') !== -1).toBeTruthy()
-  // detected valid semver node version
-  expect(
-    userAgent.match(
-      /node\.js\/\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\b/
-    )
-  ).toBeTruthy()
-})
-
 it('Parse browser user agent correctly', () => {
   mockedUtils.isNode.mockReturnValue(false)
 


### PR DESCRIPTION
Extending the creation function of the user agent with an additional object to pass in more misc info to the user agent. 

The first use case would be to add the info that the sdk was used with an adapter. 

I decided to make it generic to accept, as there might be additional information in the future and I wanted to avoid hardcoding it e.g. `usesAdapter` 