### PR TITLE
chore(eslint): adjust eslint + unblock local test setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
         'prettier',
-        'prettier/@typescript-eslint',
       ],
       plugins: ['promise'],
     },

--- a/src/freeze-sys.ts
+++ b/src/freeze-sys.ts
@@ -1,10 +1,13 @@
 // copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
 
-function deepFreeze<T>(object: T): T {
+type FreezeObject = {
+  [index: string]: any
+}
+
+function deepFreeze<T extends FreezeObject>(object: T): T {
   const propNames = Object.getOwnPropertyNames(object)
 
   for (const name of propNames) {
-    // @ts-expect-error
     const value = object[name]
 
     if (value && typeof value === 'object') {
@@ -15,8 +18,7 @@ function deepFreeze<T>(object: T): T {
   return Object.freeze(object)
 }
 
-export default function freezeSys<T>(obj: T): T {
-  // @ts-expect-error
+export default function freezeSys<T extends FreezeObject>(obj: T): T {
   deepFreeze(obj.sys || {})
   return obj
 }

--- a/src/freeze-sys.ts
+++ b/src/freeze-sys.ts
@@ -1,8 +1,6 @@
 // copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
 
-type FreezeObject = {
-  [index: string]: any
-}
+type FreezeObject = Record<string, any>
 
 function deepFreeze<T extends FreezeObject>(object: T): T {
   const propNames = Object.getOwnPropertyNames(object)

--- a/src/get-user-agent.ts
+++ b/src/get-user-agent.ts
@@ -29,9 +29,7 @@ function getBrowserOS(): string | null {
   return os
 }
 
-type OsMap = {
-  [index: string]: 'Android' | 'Linux' | 'Windows' | 'macOS'
-}
+type OsMap = Record<string,  'Android' | 'Linux' | 'Windows' | 'macOS'>
 
 function getNodeOS(): string | null {
   const os = platform() || 'linux'

--- a/src/get-user-agent.ts
+++ b/src/get-user-agent.ts
@@ -29,10 +29,14 @@ function getBrowserOS(): string | null {
   return os
 }
 
+type OsMap = {
+  [index: string]: 'Android' | 'Linux' | 'Windows' | 'macOS'
+}
+
 function getNodeOS(): string | null {
   const os = platform() || 'linux'
   const version = release() || '0.0.0'
-  const osMap = {
+  const osMap: OsMap = {
     android: 'Android',
     aix: 'Linux',
     darwin: 'macOS',
@@ -43,7 +47,6 @@ function getNodeOS(): string | null {
     win32: 'Windows',
   }
   if (os in osMap) {
-    // @ts-expect-error
     return `${osMap[os] || 'Linux'}/${version}`
   }
   return null

--- a/src/to-plain-object.ts
+++ b/src/to-plain-object.ts
@@ -6,7 +6,7 @@ import copy from 'fast-copy'
  * @param data - Any plain JSON response returned from the API
  * @return Enhanced object with toPlainObject method
  */
-export default function toPlainObject<T = object, R = T>(
+export default function toPlainObject<T = Record<string, unknown>, R = T>(
   data: T
 ): T & {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,5 +97,5 @@ export type CreateHttpClientParams = {
    * Optional maximum body length in bytes
    * @default 1073741824 i.e 1GB
    */
-   maxBodyLength?: number
+  maxBodyLength?: number
 }

--- a/test/unit/create-http-client-test.spec.ts
+++ b/test/unit/create-http-client-test.spec.ts
@@ -12,7 +12,8 @@ const logHandlerStub = jest.fn()
 const mock = new MockAdapter(axios)
 
 beforeEach(() => {
-  // @ts-expect-error
+  // @ts-expect-error No need to instantiate a complete axios instance
+  // for the mock.
   jest.spyOn(axios, 'create').mockReturnValue({})
 })
 

--- a/test/unit/utils-test.spec.ts
+++ b/test/unit/utils-test.spec.ts
@@ -9,7 +9,8 @@ describe('utils-test', () => {
     global.process.browser = true
     // detects non-node environment with babel-polyfill
     expect(isNode()).toEqual(false)
-    // @ts-expect-error
+    // @ts-expect-error TODO It's unclear why we are using the browser
+    // property here as it does not exist on type 'Process'.
     delete global.process.browser
   })
 


### PR DESCRIPTION
Some chore tasks:
- As we are using `eslint-config-prettier` on 8.0.0 we should update our eslint config according to this changelog: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
- Removed typescript errors or added description where I didn't see a quick solution. This should unblock local test runs.