### PR TITLE
feat(client): throttle requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "fast-copy": "^2.1.0",
     "lodash": "^4.17.21",
+    "p-throttle": "^4.1.1",
     "qs": "^6.9.4"
   },
   "devDependencies": {

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -1,12 +1,13 @@
 import copy from 'fast-copy'
 import qs from 'qs'
-import type { AxiosStatic } from 'axios'
-import type { AxiosInstance, CreateHttpClientParams } from './types'
+import type {AxiosStatic} from 'axios'
+import rateLimitThrottle from "./rate-limit-throttle";
+import type {AxiosInstance, CreateHttpClientParams} from './types'
 
 import rateLimit from './rate-limit'
 import asyncToken from './async-token'
 
-import { isNode, getNodeVersion } from './utils'
+import {isNode, getNodeVersion} from './utils'
 
 // Matches 'sub.host:port' or 'host:port' and extracts hostname and port
 // Also enforces toplevel domain specified, no spaces and no protocol
@@ -20,136 +21,140 @@ const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
  * @return {ContentfulAxiosInstance} Initialized axios instance
  */
 export default function createHttpClient(
-  axios: AxiosStatic,
-  options: CreateHttpClientParams
+    axios: AxiosStatic,
+    options: CreateHttpClientParams
 ): AxiosInstance {
-  const defaultConfig = {
-    insecure: false as const,
-    retryOnError: true as const,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    logHandler: (level: string, data: any): void => {
-      if (level === 'error' && data) {
-        const title = [data.name, data.message].filter((a) => a).join(' - ')
-        console.error(`[error] ${title}`)
-        console.error(data)
-        return
-      }
-      console.log(`[${level}] ${data}`)
-    },
-    // Passed to axios
-    headers: {} as Record<string, unknown>,
-    httpAgent: false as const,
-    httpsAgent: false as const,
-    timeout: 30000,
-    proxy: false as const,
-    basePath: '',
-    adapter: undefined,
-    maxContentLength: 1073741824, // 1GB
-    maxBodyLength: 1073741824, // 1GB
-  }
-  const config = {
-    ...defaultConfig,
-    ...options,
-  }
-
-  if (!config.accessToken) {
-    const missingAccessTokenError = new TypeError('Expected parameter accessToken')
-    config.logHandler('error', missingAccessTokenError)
-    throw missingAccessTokenError
-  }
-
-  // Construct axios baseURL option
-  const protocol = config.insecure ? 'http' : 'https'
-  const space = config.space ? `${config.space}/` : ''
-  let hostname = config.defaultHostname
-  let port: number | string = config.insecure ? 80 : 443
-  if (config.host && HOST_REGEX.test(config.host)) {
-    const parsed = config.host.split(':')
-    if (parsed.length === 2) {
-      ;[hostname, port] = parsed
-    } else {
-      hostname = parsed[0]
+    const defaultConfig = {
+        insecure: false as const,
+        retryOnError: true as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        logHandler: (level: string, data: any): void => {
+            if (level === 'error' && data) {
+                const title = [data.name, data.message].filter((a) => a).join(' - ')
+                console.error(`[error] ${title}`)
+                console.error(data)
+                return
+            }
+            console.log(`[${level}] ${data}`)
+        },
+        // Passed to axios
+        headers: {} as Record<string, unknown>,
+        httpAgent: false as const,
+        httpsAgent: false as const,
+        timeout: 30000,
+        throttle: 0,
+        proxy: false as const,
+        basePath: '',
+        adapter: undefined,
+        maxContentLength: 1073741824, // 1GB
+        maxBodyLength: 1073741824, // 1GB
     }
-  }
+    const config = {
+        ...defaultConfig,
+        ...options,
+    }
 
-  // Ensure that basePath does start but not end with a slash
-  if (config.basePath) {
-    config.basePath = `/${config.basePath.split('/').filter(Boolean).join('/')}`
-  }
+    if (!config.accessToken) {
+        const missingAccessTokenError = new TypeError('Expected parameter accessToken')
+        config.logHandler('error', missingAccessTokenError)
+        throw missingAccessTokenError
+    }
 
-  const baseURL =
-    options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
+    // Construct axios baseURL option
+    const protocol = config.insecure ? 'http' : 'https'
+    const space = config.space ? `${config.space}/` : ''
+    let hostname = config.defaultHostname
+    let port: number | string = config.insecure ? 80 : 443
+    if (config.host && HOST_REGEX.test(config.host)) {
+        const parsed = config.host.split(':')
+        if (parsed.length === 2) {
+            ;[hostname, port] = parsed
+        } else {
+            hostname = parsed[0]
+        }
+    }
 
-  if (!config.headers.Authorization && typeof config.accessToken !== 'function') {
-    config.headers.Authorization = 'Bearer ' + config.accessToken
-  }
+    // Ensure that basePath does start but not end with a slash
+    if (config.basePath) {
+        config.basePath = `/${config.basePath.split('/').filter(Boolean).join('/')}`
+    }
 
-  // Set these headers only for node because browsers don't like it when you
-  // override user-agent or accept-encoding.
-  // The SDKs should set their own X-Contentful-User-Agent.
-  if (isNode()) {
-    config.headers['user-agent'] = 'node.js/' + getNodeVersion()
-    config.headers['Accept-Encoding'] = 'gzip'
-  }
+    const baseURL =
+        options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
 
-  const axiosOptions = {
-    // Axios
-    baseURL,
-    headers: config.headers,
-    httpAgent: config.httpAgent,
-    httpsAgent: config.httpsAgent,
-    paramsSerializer: qs.stringify,
-    proxy: config.proxy,
-    timeout: config.timeout,
-    adapter: config.adapter,
-    maxContentLength: config.maxContentLength,
-    maxBodyLength: config.maxBodyLength,
-    // Contentful
-    logHandler: config.logHandler,
-    responseLogger: config.responseLogger,
-    requestLogger: config.requestLogger,
-    retryOnError: config.retryOnError,
-  }
-  const instance = axios.create(axiosOptions) as AxiosInstance
-  instance.httpClientParams = options
+    if (!config.headers.Authorization && typeof config.accessToken !== 'function') {
+        config.headers.Authorization = 'Bearer ' + config.accessToken
+    }
 
-  /**
-   * Creates a new axios instance with the same default base parameters as the
-   * current one, and with any overrides passed to the newParams object
-   * This is useful as the SDKs use dependency injection to get the axios library
-   * and the version of the library comes from different places depending
-   * on whether it's a browser build or a node.js build.
-   * @private
-   * @param {CreateHttpClientParams} httpClientParams - Initialization parameters for the HTTP client
-   * @return {ContentfulAxiosInstance} Initialized axios instance
-   */
-  instance.cloneWithNewParams = function (
-    newParams: Partial<CreateHttpClientParams>
-  ): AxiosInstance {
-    return createHttpClient(axios, {
-      ...copy(options),
-      ...newParams,
-    })
-  }
+    // Set these headers only for node because browsers don't like it when you
+    // override user-agent or accept-encoding.
+    // The SDKs should set their own X-Contentful-User-Agent.
+    if (isNode()) {
+        config.headers['user-agent'] = 'node.js/' + getNodeVersion()
+        config.headers['Accept-Encoding'] = 'gzip'
+    }
 
-  /**
-   * Apply interceptors.
-   * Please note that the order of interceptors is important
-   */
+    const axiosOptions = {
+        // Axios
+        baseURL,
+        headers: config.headers,
+        httpAgent: config.httpAgent,
+        httpsAgent: config.httpsAgent,
+        paramsSerializer: qs.stringify,
+        proxy: config.proxy,
+        timeout: config.timeout,
+        adapter: config.adapter,
+        maxContentLength: config.maxContentLength,
+        maxBodyLength: config.maxBodyLength,
+        // Contentful
+        logHandler: config.logHandler,
+        responseLogger: config.responseLogger,
+        requestLogger: config.requestLogger,
+        retryOnError: config.retryOnError,
+    }
+    const instance = axios.create(axiosOptions) as AxiosInstance
+    instance.httpClientParams = options
 
-  if (config.onBeforeRequest) {
-    instance.interceptors.request.use(config.onBeforeRequest)
-  }
+    /**
+     * Creates a new axios instance with the same default base parameters as the
+     * current one, and with any overrides passed to the newParams object
+     * This is useful as the SDKs use dependency injection to get the axios library
+     * and the version of the library comes from different places depending
+     * on whether it's a browser build or a node.js build.
+     * @private
+     * @param {CreateHttpClientParams} httpClientParams - Initialization parameters for the HTTP client
+     * @return {ContentfulAxiosInstance} Initialized axios instance
+     */
+    instance.cloneWithNewParams = function (
+        newParams: Partial<CreateHttpClientParams>
+    ): AxiosInstance {
+        return createHttpClient(axios, {
+            ...copy(options),
+            ...newParams,
+        })
+    }
 
-  if (typeof config.accessToken === 'function') {
-    asyncToken(instance, config.accessToken)
-  }
+    /**
+     * Apply interceptors.
+     * Please note that the order of interceptors is important
+     */
 
-  rateLimit(instance, config.retryLimit)
+    if (config.onBeforeRequest) {
+        instance.interceptors.request.use(config.onBeforeRequest)
+    }
 
-  if (config.onError) {
-    instance.interceptors.response.use((response) => response, config.onError)
-  }
+    if (typeof config.accessToken === 'function') {
+        asyncToken(instance, config.accessToken)
+    }
 
-  return instance
+    if (config.throttle > 0) {
+        rateLimitThrottle(instance, config.throttle);
+    }
+    rateLimit(instance, config.retryLimit)
+
+    if (config.onError) {
+        instance.interceptors.response.use((response) => response, config.onError)
+    }
+
+    return instance
 }

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -1,13 +1,13 @@
 import copy from 'fast-copy'
 import qs from 'qs'
-import type {AxiosStatic} from 'axios'
-import rateLimitThrottle from "./rate-limit-throttle";
-import type {AxiosInstance, CreateHttpClientParams} from './types'
+import type { AxiosStatic } from 'axios'
+import rateLimitThrottle from './rate-limit-throttle'
+import type { AxiosInstance, CreateHttpClientParams } from './types'
 
-import rateLimit from './rate-limit'
+import rateLimitRetry from './rate-limit'
 import asyncToken from './async-token'
 
-import {isNode, getNodeVersion} from './utils'
+import { isNode, getNodeVersion } from './utils'
 
 // Matches 'sub.host:port' or 'host:port' and extracts hostname and port
 // Also enforces toplevel domain specified, no spaces and no protocol
@@ -21,140 +21,140 @@ const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
  * @return {ContentfulAxiosInstance} Initialized axios instance
  */
 export default function createHttpClient(
-    axios: AxiosStatic,
-    options: CreateHttpClientParams
+  axios: AxiosStatic,
+  options: CreateHttpClientParams
 ): AxiosInstance {
-    const defaultConfig = {
-        insecure: false as const,
-        retryOnError: true as const,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        logHandler: (level: string, data: any): void => {
-            if (level === 'error' && data) {
-                const title = [data.name, data.message].filter((a) => a).join(' - ')
-                console.error(`[error] ${title}`)
-                console.error(data)
-                return
-            }
-            console.log(`[${level}] ${data}`)
-        },
-        // Passed to axios
-        headers: {} as Record<string, unknown>,
-        httpAgent: false as const,
-        httpsAgent: false as const,
-        timeout: 30000,
-        throttle: 0,
-        proxy: false as const,
-        basePath: '',
-        adapter: undefined,
-        maxContentLength: 1073741824, // 1GB
-        maxBodyLength: 1073741824, // 1GB
+  const defaultConfig = {
+    insecure: false as const,
+    retryOnError: true as const,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logHandler: (level: string, data: any): void => {
+      if (level === 'error' && data) {
+        const title = [data.name, data.message].filter((a) => a).join(' - ')
+        console.error(`[error] ${title}`)
+        console.error(data)
+        return
+      }
+      console.log(`[${level}] ${data}`)
+    },
+    // Passed to axios
+    headers: {} as Record<string, unknown>,
+    httpAgent: false as const,
+    httpsAgent: false as const,
+    timeout: 30000,
+    throttle: 0,
+    proxy: false as const,
+    basePath: '',
+    adapter: undefined,
+    maxContentLength: 1073741824, // 1GB
+    maxBodyLength: 1073741824, // 1GB
+  }
+  const config = {
+    ...defaultConfig,
+    ...options,
+  }
+
+  if (!config.accessToken) {
+    const missingAccessTokenError = new TypeError('Expected parameter accessToken')
+    config.logHandler('error', missingAccessTokenError)
+    throw missingAccessTokenError
+  }
+
+  // Construct axios baseURL option
+  const protocol = config.insecure ? 'http' : 'https'
+  const space = config.space ? `${config.space}/` : ''
+  let hostname = config.defaultHostname
+  let port: number | string = config.insecure ? 80 : 443
+  if (config.host && HOST_REGEX.test(config.host)) {
+    const parsed = config.host.split(':')
+    if (parsed.length === 2) {
+      ;[hostname, port] = parsed
+    } else {
+      hostname = parsed[0]
     }
-    const config = {
-        ...defaultConfig,
-        ...options,
-    }
+  }
 
-    if (!config.accessToken) {
-        const missingAccessTokenError = new TypeError('Expected parameter accessToken')
-        config.logHandler('error', missingAccessTokenError)
-        throw missingAccessTokenError
-    }
+  // Ensure that basePath does start but not end with a slash
+  if (config.basePath) {
+    config.basePath = `/${config.basePath.split('/').filter(Boolean).join('/')}`
+  }
 
-    // Construct axios baseURL option
-    const protocol = config.insecure ? 'http' : 'https'
-    const space = config.space ? `${config.space}/` : ''
-    let hostname = config.defaultHostname
-    let port: number | string = config.insecure ? 80 : 443
-    if (config.host && HOST_REGEX.test(config.host)) {
-        const parsed = config.host.split(':')
-        if (parsed.length === 2) {
-            ;[hostname, port] = parsed
-        } else {
-            hostname = parsed[0]
-        }
-    }
+  const baseURL =
+    options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
 
-    // Ensure that basePath does start but not end with a slash
-    if (config.basePath) {
-        config.basePath = `/${config.basePath.split('/').filter(Boolean).join('/')}`
-    }
+  if (!config.headers.Authorization && typeof config.accessToken !== 'function') {
+    config.headers.Authorization = 'Bearer ' + config.accessToken
+  }
 
-    const baseURL =
-        options.baseURL || `${protocol}://${hostname}:${port}${config.basePath}/spaces/${space}`
+  // Set these headers only for node because browsers don't like it when you
+  // override user-agent or accept-encoding.
+  // The SDKs should set their own X-Contentful-User-Agent.
+  if (isNode()) {
+    config.headers['user-agent'] = 'node.js/' + getNodeVersion()
+    config.headers['Accept-Encoding'] = 'gzip'
+  }
 
-    if (!config.headers.Authorization && typeof config.accessToken !== 'function') {
-        config.headers.Authorization = 'Bearer ' + config.accessToken
-    }
+  const axiosOptions = {
+    // Axios
+    baseURL,
+    headers: config.headers,
+    httpAgent: config.httpAgent,
+    httpsAgent: config.httpsAgent,
+    paramsSerializer: qs.stringify,
+    proxy: config.proxy,
+    timeout: config.timeout,
+    adapter: config.adapter,
+    maxContentLength: config.maxContentLength,
+    maxBodyLength: config.maxBodyLength,
+    // Contentful
+    logHandler: config.logHandler,
+    responseLogger: config.responseLogger,
+    requestLogger: config.requestLogger,
+    retryOnError: config.retryOnError,
+  }
+  const instance = axios.create(axiosOptions) as AxiosInstance
+  instance.httpClientParams = options
 
-    // Set these headers only for node because browsers don't like it when you
-    // override user-agent or accept-encoding.
-    // The SDKs should set their own X-Contentful-User-Agent.
-    if (isNode()) {
-        config.headers['user-agent'] = 'node.js/' + getNodeVersion()
-        config.headers['Accept-Encoding'] = 'gzip'
-    }
+  /**
+   * Creates a new axios instance with the same default base parameters as the
+   * current one, and with any overrides passed to the newParams object
+   * This is useful as the SDKs use dependency injection to get the axios library
+   * and the version of the library comes from different places depending
+   * on whether it's a browser build or a node.js build.
+   * @private
+   * @param {CreateHttpClientParams} httpClientParams - Initialization parameters for the HTTP client
+   * @return {ContentfulAxiosInstance} Initialized axios instance
+   */
+  instance.cloneWithNewParams = function (
+    newParams: Partial<CreateHttpClientParams>
+  ): AxiosInstance {
+    return createHttpClient(axios, {
+      ...copy(options),
+      ...newParams,
+    })
+  }
 
-    const axiosOptions = {
-        // Axios
-        baseURL,
-        headers: config.headers,
-        httpAgent: config.httpAgent,
-        httpsAgent: config.httpsAgent,
-        paramsSerializer: qs.stringify,
-        proxy: config.proxy,
-        timeout: config.timeout,
-        adapter: config.adapter,
-        maxContentLength: config.maxContentLength,
-        maxBodyLength: config.maxBodyLength,
-        // Contentful
-        logHandler: config.logHandler,
-        responseLogger: config.responseLogger,
-        requestLogger: config.requestLogger,
-        retryOnError: config.retryOnError,
-    }
-    const instance = axios.create(axiosOptions) as AxiosInstance
-    instance.httpClientParams = options
+  /**
+   * Apply interceptors.
+   * Please note that the order of interceptors is important
+   */
 
-    /**
-     * Creates a new axios instance with the same default base parameters as the
-     * current one, and with any overrides passed to the newParams object
-     * This is useful as the SDKs use dependency injection to get the axios library
-     * and the version of the library comes from different places depending
-     * on whether it's a browser build or a node.js build.
-     * @private
-     * @param {CreateHttpClientParams} httpClientParams - Initialization parameters for the HTTP client
-     * @return {ContentfulAxiosInstance} Initialized axios instance
-     */
-    instance.cloneWithNewParams = function (
-        newParams: Partial<CreateHttpClientParams>
-    ): AxiosInstance {
-        return createHttpClient(axios, {
-            ...copy(options),
-            ...newParams,
-        })
-    }
+  if (config.onBeforeRequest) {
+    instance.interceptors.request.use(config.onBeforeRequest)
+  }
 
-    /**
-     * Apply interceptors.
-     * Please note that the order of interceptors is important
-     */
+  if (typeof config.accessToken === 'function') {
+    asyncToken(instance, config.accessToken)
+  }
 
-    if (config.onBeforeRequest) {
-        instance.interceptors.request.use(config.onBeforeRequest)
-    }
+  if (config.throttle) {
+    rateLimitThrottle(instance, config.throttle)
+  }
+  rateLimitRetry(instance, config.retryLimit)
 
-    if (typeof config.accessToken === 'function') {
-        asyncToken(instance, config.accessToken)
-    }
+  if (config.onError) {
+    instance.interceptors.response.use((response) => response, config.onError)
+  }
 
-    if (config.throttle > 0) {
-        rateLimitThrottle(instance, config.throttle);
-    }
-    rateLimit(instance, config.retryLimit)
-
-    if (config.onError) {
-        instance.interceptors.response.use((response) => response, config.onError)
-    }
-
-    return instance
+  return instance
 }

--- a/src/rate-limit-throttle.ts
+++ b/src/rate-limit-throttle.ts
@@ -1,15 +1,75 @@
-import pThrottle from "p-throttle";
-import {AxiosInstance} from "./types";
+import { isString, noop } from 'lodash'
+import pThrottle from 'p-throttle'
+import { AxiosInstance } from './types'
 
-export default (axiosInstance: AxiosInstance, limit = 7) => {
-    const throttle = pThrottle({
-        limit,
-        interval: 1000
-    });
+type ThrottleType = 'auto' | `${number}%`
 
-    const interceptorId = axiosInstance.interceptors.request.use((config) => {
-        return throttle<[], typeof config>(() => config)()
-    }, Promise.reject)
+const PERCENTAGE_REGEX = /(?<value>\d+)(%)/
 
-    return () => axiosInstance.interceptors.request.eject(interceptorId);
+function calculateLimit(type: ThrottleType, max = 7) {
+  let limit = max
+
+  if (PERCENTAGE_REGEX.test(type)) {
+    const groups = type.match(PERCENTAGE_REGEX)?.groups
+    if (groups && groups.value) {
+      const percentage = parseInt(groups.value) / 100
+      limit = Math.round(max * percentage)
+    }
+  }
+  return Math.min(30, Math.max(1, limit))
+}
+
+function createThrottle(limit: number, logger: (...args: unknown[]) => void) {
+  logger('info', `Throttle request to ${limit}/s`)
+  return pThrottle({
+    limit,
+    interval: 1000,
+    strict: false,
+  })
+}
+
+export default (axiosInstance: AxiosInstance, type: ThrottleType | number = 'auto') => {
+  const { logHandler = noop } = axiosInstance.defaults
+  let limit = isString(type) ? calculateLimit(type) : calculateLimit('auto', type)
+  let throttle = createThrottle(limit, logHandler)
+  let isCalculated = false
+
+  let requestInterceptorId = axiosInstance.interceptors.request.use((config) => {
+    return throttle<[], typeof config>(() => config)()
+  }, Promise.reject)
+
+  const responseInterceptorId = axiosInstance.interceptors.response.use((response) => {
+    if (
+      !isCalculated &&
+      isString(type) &&
+      (type === 'auto' || PERCENTAGE_REGEX.test(type)) &&
+      response.headers &&
+      response.headers['x-contentful-ratelimit-second-limit']
+    ) {
+      const rawLimit = parseInt(response.headers['x-contentful-ratelimit-second-limit'])
+      const nextLimit = calculateLimit(type, rawLimit)
+
+      if (nextLimit !== limit) {
+        if (requestInterceptorId) {
+          axiosInstance.interceptors.request.eject(requestInterceptorId)
+        }
+
+        limit = nextLimit
+
+        throttle = createThrottle(nextLimit, logHandler)
+        requestInterceptorId = axiosInstance.interceptors.request.use((config) => {
+          return throttle<[], typeof config>(() => config)()
+        }, Promise.reject)
+      }
+
+      isCalculated = true
+    }
+
+    return response
+  }, Promise.reject)
+
+  return () => {
+    axiosInstance.interceptors.request.eject(requestInterceptorId)
+    axiosInstance.interceptors.response.eject(responseInterceptorId)
+  }
 }

--- a/src/rate-limit-throttle.ts
+++ b/src/rate-limit-throttle.ts
@@ -1,0 +1,15 @@
+import pThrottle from "p-throttle";
+import {AxiosInstance} from "./types";
+
+export default (axiosInstance: AxiosInstance, limit = 7) => {
+    const throttle = pThrottle({
+        limit,
+        interval: 1000
+    });
+
+    const interceptorId = axiosInstance.interceptors.request.use((config) => {
+        return throttle<[], typeof config>(() => config)()
+    }, Promise.reject)
+
+    return () => axiosInstance.interceptors.request.eject(interceptorId);
+}

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,11 +1,8 @@
+import { noop } from 'lodash'
 import type { AxiosInstance } from './types'
 
 const attempts: Record<string, number> = {}
 let networkErrorAttempts = 0
-
-function noop(): undefined {
-  return undefined
-}
 
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => {

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -44,7 +44,7 @@ export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
       let retryErrorType = null
       let wait = 0
 
-      // Errors without response did not recieve anything from the server
+      // Errors without response did not receive anything from the server
       if (!response) {
         retryErrorType = 'Connection'
         networkErrorAttempts++

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,10 +99,11 @@ export type CreateHttpClientParams = {
    */
   maxBodyLength?: number
 
-    /**
-     * Optional maximum number of requests per second (rate-limit)
-     * @desc should represent the max of your current plan's rate limit
-     * @default 0 = no throttling
-     */
-  throttle?: number
+  /**
+   * Optional maximum number of requests per second (rate-limit)
+   * @desc should represent the max of your current plan's rate limit
+   * @default 0 = no throttling
+   * @param 1-30 (fixed number of limit), 'auto' (calculated limit based on current tier), '0%' - '100%' (calculated % limit based on tier)
+   */
+  throttle?: 'auto' | `${number}%` | number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,4 +98,11 @@ export type CreateHttpClientParams = {
    * @default 1073741824 i.e 1GB
    */
   maxBodyLength?: number
+
+    /**
+     * Optional maximum number of requests per second (rate-limit)
+     * @desc should represent the max of your current plan's rate limit
+     * @default 0 = no throttling
+     */
+  throttle?: number
 }

--- a/test/unit/create-http-client-test.spec.ts
+++ b/test/unit/create-http-client-test.spec.ts
@@ -4,6 +4,7 @@ import axios, { AxiosAdapter } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 
 jest.mock('../../src/rate-limit', () => jest.fn())
+jest.mock('../../src/rate-limit-throttle', () => jest.fn())
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
 

--- a/test/unit/rate-limit-test.spec.ts
+++ b/test/unit/rate-limit-test.spec.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 
 import createHttpClient from '../../src/create-http-client'
-import { CreateHttpClientParams } from '../../src/types'
+import { CreateHttpClientParams } from '../../src'
 
 const logHandlerStub = jest.fn()
 

--- a/test/unit/rate-limit-throttle.spec.ts
+++ b/test/unit/rate-limit-throttle.spec.ts
@@ -1,60 +1,118 @@
+/* eslint @typescript-eslint/ban-ts-comment: 0 */
+
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
+import { AxiosInstance } from '../../src'
 import createHttpClient from '../../src/create-http-client'
-
-const mock = new MockAdapter(axios)
-
-const waitASecond = () => new Promise((resolve) => {
-    setTimeout(resolve, 1000)
-})
-
-mock.onGet('/throttled-call').reply(200, null)
 
 const logHandlerStub = jest.fn()
 
+function wait(ms = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+function executeCalls(client: AxiosInstance, callsCount: number) {
+  const requests = []
+  for (let i = 0; i < callsCount; i++) {
+    requests.push(client.get('/throttled-call'))
+  }
+  return requests
+}
+
 describe('throttle to rate limit axios interceptor', () => {
+  let mock = new MockAdapter(axios)
 
-    beforeEach(()=> {
-        mock.resetHistory();
+  beforeEach(() => {
+    mock = new MockAdapter(axios)
+    mock.onGet('/throttled-call').reply(200, null, { 'x-contentful-ratelimit-second-limit': 10 })
+  })
+
+  afterEach(() => {
+    logHandlerStub.mockReset()
+  })
+
+  async function expectCallsExecutedWithin(
+    client: AxiosInstance,
+    callsCount: number,
+    duration: number
+  ) {
+    // initial call to potentially update throttling settings
+    client.get('/throttled-call')
+    await wait(1000)
+
+    const calls = executeCalls(client, callsCount)
+
+    const start = Date.now()
+    await Promise.all(calls)
+    expect(mock.history.get).toHaveLength(callsCount + 1)
+
+    expect(Date.now() - start).toBeLessThanOrEqual(duration)
+  }
+
+  function expectLogHandlerHasBeenCalled(limit: number, callCount: number) {
+    expect(logHandlerStub).toBeCalledTimes(callCount)
+    expect(logHandlerStub.mock.calls[callCount - 1][0]).toEqual('info')
+    expect(logHandlerStub.mock.calls[callCount - 1][1]).toContain(`Throttle request to ${limit}/s`)
+  }
+
+  it('fires all requests directly', async () => {
+    const client = createHttpClient(axios, {
+      accessToken: 'token',
+      logHandler: logHandlerStub,
+      throttle: 0,
     })
+    await expectCallsExecutedWithin(client, 20, 100)
+    expect(logHandlerStub).not.toHaveBeenCalled()
+  })
 
-    it('fires all requests directly', async () => {
-
-        const client = createHttpClient(axios, {
-            accessToken: 'token',
-            logHandler: logHandlerStub,
-            throttle: 0
-        })
-
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-
-        await waitASecond()
-        expect(mock.history.get).toHaveLength(8);
+  it('fires limited requests per second', async () => {
+    const client = createHttpClient(axios, {
+      accessToken: 'token',
+      logHandler: logHandlerStub,
+      throttle: 3,
     })
+    await expectCallsExecutedWithin(client, 3, 1010)
+    expectLogHandlerHasBeenCalled(3, 1)
+  })
 
-    it('fires limited requests per second', async () => {
-
-        const client = createHttpClient(axios, {
-            accessToken: 'token',
-            logHandler: logHandlerStub,
-            throttle: 3
-        })
-
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-        client.get('/throttled-call')
-
-        await waitASecond()
-        expect(mock.history.get).toHaveLength(3);
+  it('invalid argument defaults to 7/s', async () => {
+    const client = createHttpClient(axios, {
+      accessToken: 'token',
+      logHandler: logHandlerStub,
+      // @ts-ignore
+      throttle: 'invalid',
     })
+    await expectCallsExecutedWithin(client, 7, 1010)
+    expectLogHandlerHasBeenCalled(7, 1)
+  })
 
+  it('calculate limit based on response header', async () => {
+    const client = createHttpClient(axios, {
+      accessToken: 'token',
+      logHandler: logHandlerStub,
+      throttle: 'auto',
+    })
+    await expectCallsExecutedWithin(client, 10, 1010)
+    expectLogHandlerHasBeenCalled(10, 2)
+  })
+
+  it.each([
+    { throttle: '30%', limit: 3, duration: 1010 },
+    { throttle: '50%', limit: 5, duration: 1010 },
+    { throttle: '70%', limit: 7, duration: 1010 },
+  ])(
+    'calculate $throttle limit based on response header',
+    async ({ throttle, limit, duration }) => {
+      const client = createHttpClient(axios, {
+        accessToken: 'token',
+        logHandler: logHandlerStub,
+        // @ts-ignore
+        throttle: throttle,
+      })
+      await expectCallsExecutedWithin(client, limit, duration)
+      expectLogHandlerHasBeenCalled(limit, 2)
+    }
+  )
 })
-

--- a/test/unit/rate-limit-throttle.spec.ts
+++ b/test/unit/rate-limit-throttle.spec.ts
@@ -1,0 +1,60 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import createHttpClient from '../../src/create-http-client'
+
+const mock = new MockAdapter(axios)
+
+const waitASecond = () => new Promise((resolve) => {
+    setTimeout(resolve, 1000)
+})
+
+mock.onGet('/throttled-call').reply(200, null)
+
+const logHandlerStub = jest.fn()
+
+describe('throttle to rate limit axios interceptor', () => {
+
+    beforeEach(()=> {
+        mock.resetHistory();
+    })
+
+    it('fires all requests directly', async () => {
+
+        const client = createHttpClient(axios, {
+            accessToken: 'token',
+            logHandler: logHandlerStub,
+            throttle: 0
+        })
+
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+
+        await waitASecond()
+        expect(mock.history.get).toHaveLength(8);
+    })
+
+    it('fires limited requests per second', async () => {
+
+        const client = createHttpClient(axios, {
+            accessToken: 'token',
+            logHandler: logHandlerStub,
+            throttle: 3
+        })
+
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+        client.get('/throttled-call')
+
+        await waitASecond()
+        expect(mock.history.get).toHaveLength(3);
+    })
+
+})
+


### PR DESCRIPTION
The max amount of CMA requests we can send per second ist defined by the customers tier (`7`, `10`, `30`).
This PR adds a client param `throttle` to set the max requests the client can sends per second. If not defined or set to `0`, nothing will be throttled.