### PR TITLE
fix: retry on error [ZEND-1616]

### DIFF
--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,13 +1,14 @@
 import { noop } from './utils'
 import type { AxiosInstance } from './types'
 
-const attempts: Record<string, number> = {}
-let networkErrorAttempts = 0
-
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms)
   })
+
+const defaultWait = (attempts: number): number => {
+  return Math.pow(Math.SQRT2, attempts)
+}
 
 export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
   const { responseLogger = noop, requestLogger = noop } = instance.defaults
@@ -30,7 +31,7 @@ export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
       return response
     },
     function (error) {
-      let { response } = error
+      const { response } = error
       const { config } = error
       responseLogger(error)
       // Do not retry if it is disabled or no request config exists (not an axios error)
@@ -38,39 +39,22 @@ export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
         return Promise.reject(error)
       }
 
+      // Retried already for max attempts
+      const doneAttempts = config.attempts || 1
+      if (doneAttempts > maxRetry) {
+        error.attempts = config.attempts
+        return Promise.reject(error)
+      }
+
       let retryErrorType = null
-      let wait = 0
+      let wait = defaultWait(doneAttempts)
 
       // Errors without response did not receive anything from the server
       if (!response) {
         retryErrorType = 'Connection'
-        networkErrorAttempts++
-
-        if (networkErrorAttempts > maxRetry) {
-          error.attempts = networkErrorAttempts
-          return Promise.reject(error)
-        }
-
-        wait = Math.pow(Math.SQRT2, networkErrorAttempts)
-        response = {}
-      } else {
-        networkErrorAttempts = 0
-      }
-
-      if (response.status >= 500 && response.status < 600) {
+      } else if (response.status >= 500 && response.status < 600) {
         // 5** errors are server related
         retryErrorType = `Server ${response.status}`
-        const headers = response.headers || {}
-        const requestId = headers['x-contentful-request-id'] || null
-        attempts[requestId] = attempts[requestId] || 0
-        attempts[requestId]++
-
-        // we reject if there are too many errors with the same request id or request id is not defined
-        if (attempts[requestId] > maxRetry || !requestId) {
-          error.attempts = attempts[requestId]
-          return Promise.reject(error)
-        }
-        wait = Math.pow(Math.SQRT2, attempts[requestId])
       } else if (response.status === 429) {
         // 429 errors are exceeded rate limit exceptions
         retryErrorType = 'Rate limit'
@@ -87,6 +71,9 @@ export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
           'warning',
           `${retryErrorType} error occurred. Waiting for ${wait} ms before retrying...`
         )
+
+        // increase attempts counter
+        config.attempts = doneAttempts + 1
 
         /* Somehow between the interceptor and retrying the request the httpAgent/httpsAgent gets transformed from an Agent-like object
          to a regular object, causing failures on retries after rate limits. Removing these properties here fixes the error, but retry

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,4 +106,10 @@ export type CreateHttpClientParams = {
    * @param 1-30 (fixed number of limit), 'auto' (calculated limit based on current tier), '0%' - '100%' (calculated % limit based on tier)
    */
   throttle?: 'auto' | string | number
+
+  /**
+   * Optional how often the current request has been retried
+   * @default 0
+   */
+  attempt?: number
 }


### PR DESCRIPTION
The Contentful API will always return a unique request-id so using this for counting retries will not work.

Instead pass the number of attempts to the next axios calls, which also fixes a memory leak as the retry attempts object was never cleared.