### PR TITLE
fix(dep): Bump fast-copy to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "fast-copy": "^2.1.0",
+    "fast-copy": "^2.1.3",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "p-throttle": "^4.1.1",


### PR DESCRIPTION
Bump fast-copy to 2.1.3 to avoid problems in contentful.js caused by an older version: https://github.com/contentful/contentful.js/pull/1216