### PR TITLE
chore: init vault [SDK-2396]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,0 +1,8 @@
+version: 1
+services:
+  github-action:
+    policies:
+      - dependabot
+  circleci:
+    policies:
+      - semantic-release-ecosystem

--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -1,14 +1,15 @@
 name: "dependabot approve-and-request-merge"
 
-on:
-  pull_request_target
+on: pull_request_target
 
 jobs:
   worker:
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
-
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: contentful/dependabot-auto-merge@v1
+      - uses: contentful/github-auto-merge@v1
         with:
-          github_token: ${{ secrets.CF_ECOSYSTEM_BOT_GITHUB_TOKEN_AUTO_APPROVE }}
+          VAULT_URL: ${{ secrets.VAULT_URL }}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "husky": "^7.0.0",
     "in-publish": "^2.0.0",
-    "jest": "^27.5.1",
+    "jest": "^29.3.1",
     "lint-staged": "^13.0.0",
     "mkdirp": "^1.0.4",
     "moxios": "^0.4.0",
@@ -99,7 +99,7 @@
     "rollup": "^2.34.0",
     "rollup-plugin-babel": "^4.4.0",
     "semantic-release": "^17.0.7",
-    "ts-jest": "^27.1.3",
+    "ts-jest": "^29.0.3",
     "tslib": "^2.0.3",
     "typescript": "^4.5.5"
   },


### PR DESCRIPTION
Adds the vault file with the policy needed for building and deploying ecosystem packages.

Also as part of the "auto-migration" it updated the dependabot workflow.