### PR TITLE
fix(): remove setting customer headers [NONE]

### DIFF
--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -8,8 +8,6 @@ import type { AxiosInstance, CreateHttpClientParams } from './types'
 import rateLimitRetry from './rate-limit'
 import asyncToken from './async-token'
 
-import { isNode, getNodeVersion } from './utils'
-
 // Matches 'sub.host:port' or 'host:port' and extracts hostname and port
 // Also enforces toplevel domain specified, no spaces and no protocol
 const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
@@ -85,14 +83,6 @@ export default function createHttpClient(
 
   if (!config.headers.Authorization && typeof config.accessToken !== 'function') {
     config.headers.Authorization = 'Bearer ' + config.accessToken
-  }
-
-  // Set these headers only for node because browsers don't like it when you
-  // override user-agent or accept-encoding.
-  // The SDKs should set their own X-Contentful-User-Agent.
-  if (isNode()) {
-    config.headers['user-agent'] = 'node.js/' + getNodeVersion()
-    config.headers['Accept-Encoding'] = 'gzip'
   }
 
   const axiosOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,10 @@
 export function isNode(): boolean {
   /**
-   * Polyfills of 'process' might set process.browser === true
-   *
-   * See:
-   * https://github.com/webpack/node-libs-browser/blob/master/mock/process.js#L8
-   * https://github.com/defunctzombie/node-process/blob/master/browser.js#L156
-   **/
-  return typeof process !== 'undefined' && !process.browser
+   * Save way to check for the global scope which should confirm if an environment is node
+   * For reference: https://stackoverflow.com/a/31090240
+   */
+  const isNodeFunc = new Function('try {return this===global;}catch(e){return false;}')
+  return isNodeFunc()
 }
 
 export function isReactNative(): boolean {

--- a/test/unit/utils-test.spec.ts
+++ b/test/unit/utils-test.spec.ts
@@ -7,17 +7,6 @@ describe('utils-test', () => {
     expect(isNode()).toEqual(true)
   })
 
-  it('Detects node properly with babel-polyfill', () => {
-    // @ts-ignore
-    global.process.browser = true
-    // detects non-node environment with babel-polyfill
-    expect(isNode()).toEqual(false)
-    // property here as it does not exist on type 'Process'.
-    // TODO It's unclear why we are using the browser
-    // @ts-ignore
-    delete global.process.browser
-  })
-
   it('Detects node version', () => {
     const version = getNodeVersion()
     expect(


### PR DESCRIPTION
Remove the setting of custom headers 'Accept-Encoding' and 'user-agent'. 
Previously those headers were set manually in node environments. Nowadays that should not be necessary anymore since the request library sets the header according to the environment's abilities.

Will prevent problems where e.g. browser environments were wrongly identified as node environments leading to errors like `Refused to set unsafe header "Accept-Encoding" `