### PR TITLE
fix(): revert "fix(): improve isNode check" to enable csp

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,12 @@
 export function isNode(): boolean {
   /**
-   * Save way to check for the global scope which should confirm if an environment is node
-   * For reference: https://stackoverflow.com/a/31090240
-   */
-  const isNodeFunc = new Function('try {return this===global;}catch(e){return false;}')
-  return isNodeFunc()
+   * Polyfills of 'process' might set process.browser === true
+   *
+   * See:
+   * https://github.com/webpack/node-libs-browser/blob/master/mock/process.js#L8
+   * https://github.com/defunctzombie/node-process/blob/master/browser.js#L156
+   **/
+  return typeof process !== 'undefined' && !process.browser
 }
 
 export function isReactNative(): boolean {

--- a/test/unit/utils-test.spec.ts
+++ b/test/unit/utils-test.spec.ts
@@ -7,6 +7,17 @@ describe('utils-test', () => {
     expect(isNode()).toEqual(true)
   })
 
+  it('Detects node properly with babel-polyfill', () => {
+    // @ts-ignore
+    global.process.browser = true
+    // detects non-node environment with babel-polyfill
+    expect(isNode()).toEqual(false)
+    // property here as it does not exist on type 'Process'.
+    // TODO It's unclear why we are using the browser
+    // @ts-ignore
+    delete global.process.browser
+  })
+
   it('Detects node version', () => {
     const version = getNodeVersion()
     expect(


### PR DESCRIPTION
Reverting https://github.com/contentful/contentful-sdk-core/pull/331/commits/2721dcf09a775f6744afdc08c9e5b3836854fe79 because the use of the function constructor will cause the `contentful.browser.min.js` bundle of `contentful.js` to be blocked by CSPs, see https://web.dev/csp/#eval-too. 

This is to unblock the usage of the bundle again, but happy about other approaches to improve the node check as was suggested here (https://github.com/contentful/contentful-sdk-core/pull/331#issuecomment-1399971519).