### PR TITLE
fix: re-introduce paramsSerializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "fast-copy": "^2.1.7",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
-    "p-throttle": "^4.1.1"
+    "p-throttle": "^4.1.1",
+    "qs": "^6.11.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",
@@ -65,6 +66,7 @@
     "@types/jest": "^29.2.2",
     "@types/lodash.isplainobject": "^4.0.6",
     "@types/lodash.isstring": "^4.0.6",
+    "@types/qs": "^6.9.10",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "axios": "^1.6.0",

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -2,6 +2,7 @@ import { AxiosRequestHeaders } from 'axios'
 import type { AxiosStatic } from 'axios'
 import copy from 'fast-copy'
 import asyncToken from './async-token'
+import qs from 'qs'
 
 import rateLimitRetry from './rate-limit'
 import rateLimitThrottle from './rate-limit-throttle'
@@ -94,6 +95,11 @@ export default function createHttpClient(
     adapter: config.adapter,
     maxContentLength: config.maxContentLength,
     maxBodyLength: config.maxBodyLength,
+    paramsSerializer: {
+      serialize: (params) => {
+        return qs.stringify(params)
+      },
+    },
     // Contentful
     logHandler: config.logHandler,
     responseLogger: config.responseLogger,


### PR DESCRIPTION
We reintroduce the `paramsSerializer` (again) after removing it [here](https://github.com/contentful/contentful-sdk-core/pull/370).

This is to unblock [the axios bump in contentful-merge](https://github.com/contentful/contentful-merge/pull/462) or the skd-core bump [as such](https://github.com/contentful/contentful-merge/pull/552). We saw that tests were failing because the query set together [here](https://github.com/contentful/contentful-merge/blob/main/src/engine/create-changeset/tasks/create-fetch-partial-entities-task.ts#L43) can not properly be handled by the API anymore and instead runs into

`error: InvalidQuery: The query you sent was invalid. Probably a filter or ordering specification is not applicable to the type of a field.`

Tested locally on `contentful.js` and `contentful-merge`
