### PR TITLE
feat: enable 'fetch' adapter + duplicate request params fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@types/qs": "^6.9.10",
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
-        "axios": "^1.6.0",
+        "axios": "^1.7.2",
         "axios-mock-adapter": "^1.20.0",
         "babel-eslint": "^10.1.0",
         "bundlesize": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/qs": "^6.9.10",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
-    "axios": "^1.6.0",
+    "axios": "^1.7.2",
     "axios-mock-adapter": "^1.20.0",
     "babel-eslint": "^10.1.0",
     "bundlesize": "^0.18.1",


### PR DESCRIPTION
- enables consumers of this package (CDA.js and CMA.js) to instantiate axios clients using the new `fetch` adapter that was introduced in [`axios` 1.7.0](https://github.com/axios/axios/releases/tag/v1.7.0)
- fixes a bug that was introduced with the upgrade of axios version from `1.6.8` to `1.7.x`