### PR TITLE
fix: do not remove query parameters on retry

### DIFF
--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -81,14 +81,6 @@ export default function rateLimit(instance: AxiosInstance, maxRetry = 5): void {
         delete config.httpAgent
         delete config.httpsAgent
 
-        /**
-         * Hack to mitigate (likely) bug introduced in axios v1.7.0 where `url`,
-         * when using the default `xhr` adapter, is a fully qualified URL (instead of a path),
-         * which somehow causes the request params to be repeatedly appended
-         * to the final request URL upon each retry.
-         */
-        config.url = config.url.split('?')[0]
-
         return delay(wait).then(() => instance(config))
       }
       return Promise.reject(error)

--- a/test/unit/rate-limit-test.spec.ts
+++ b/test/unit/rate-limit-test.spec.ts
@@ -187,4 +187,4 @@ it('Preserves URI query parameters between retries', async () => {
   for (const request of mock.history.get) {
     expect(request.url).toEqual(uri)
   }
-});
+})


### PR DESCRIPTION
Fixes #513.
This is a draft fix intended to start the discussion.

I'm not sure if it's okay to remove the existing hack introduced in #483. Before making a decision, I’d like to learn more about the duplicate request parameters problem and how I can reproduce it in a test.

@t-col probably you could give me some hints?