### PR TITLE
fix: don't copy httpsAgent [EXT-5676]

### DIFF
--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -14,7 +14,8 @@ const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
 
 function copyHttpClientParams(options: CreateHttpClientParams): CreateHttpClientParams {
   const copiedOptions = copy(options)
-  // httpsAgent cannot be copied because it can contain private fields that are not enumerable
+  // httpAgent and httpsAgent cannot be copied because they can contain private fields
+  copiedOptions.httpAgent = options.httpAgent
   copiedOptions.httpsAgent = options.httpsAgent
   return copiedOptions
 }

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -12,6 +12,16 @@ import type { AxiosInstance, CreateHttpClientParams, DefaultOptions } from './ty
 // Also enforces toplevel domain specified, no spaces and no protocol
 const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
 
+function copyHttpClientParams(options: CreateHttpClientParams): CreateHttpClientParams {
+  // httpsAgent is omitted from the deep copy operation,
+  // because it can contain private fields that are not enumerable
+  const { httpsAgent, ...optionsToCopy } = options
+  return {
+    ...copy(optionsToCopy),
+    httpsAgent,
+  }
+}
+
 /**
  * Create pre-configured axios instance
  * @private
@@ -124,7 +134,7 @@ export default function createHttpClient(
     newParams: Partial<CreateHttpClientParams>,
   ): AxiosInstance {
     return createHttpClient(axios, {
-      ...copy(options),
+      ...copyHttpClientParams(options),
       ...newParams,
     })
   }

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -13,13 +13,10 @@ import type { AxiosInstance, CreateHttpClientParams, DefaultOptions } from './ty
 const HOST_REGEX = /^(?!\w+:\/\/)([^\s:]+\.?[^\s:]+)(?::(\d+))?(?!:)$/
 
 function copyHttpClientParams(options: CreateHttpClientParams): CreateHttpClientParams {
-  // httpsAgent is omitted from the deep copy operation,
-  // because it can contain private fields that are not enumerable
-  const { httpsAgent, ...optionsToCopy } = options
-  return {
-    ...copy(optionsToCopy),
-    httpsAgent,
-  }
+  const copiedOptions = copy(options)
+  // httpsAgent cannot be copied because it can contain private fields that are not enumerable
+  copiedOptions.httpsAgent = options.httpsAgent
+  return copiedOptions
 }
 
 /**


### PR DESCRIPTION
Customers face issues using custom `httpsAgent`s that utilized private fields. Since these fields are not enumerable, they are not copyable, and must be excluded from the deep copy that is utilized to ensure we avoid mutating things unnecessarily.