### PR TITLE
chore: replace qs with picoquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "fast-copy": "^3.0.2",
         "lodash": "^4.17.21",
         "p-throttle": "^6.1.0",
-        "process": "^0.11.10",
-        "qs": "^6.12.3"
+        "picoquery": "^1.4.0",
+        "process": "^0.11.10"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -22,7 +22,6 @@
         "@semantic-release/npm": "^12.0.1",
         "@semantic-release/release-notes-generator": "^14.0.0",
         "@types/lodash": "^4.17.6",
-        "@types/qs": "^6.9.10",
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
         "@vitest/coverage-v8": "^2.0.2",
@@ -1994,11 +1993,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "dev": true
-    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -2860,7 +2854,9 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3466,7 +3462,9 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3707,7 +3705,9 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -3717,7 +3717,9 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4425,6 +4427,12 @@
       "version": "3.0.2",
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -4708,6 +4716,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4759,7 +4768,9 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -5002,7 +5013,9 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -5070,7 +5083,9 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5080,7 +5095,9 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5090,7 +5107,9 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5117,6 +5136,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9809,7 +9829,9 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10273,6 +10295,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/picoquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-1.4.0.tgz",
+      "integrity": "sha512-VIq9N+nQgmiN6DsAgs7EcAjUezgppBR4zahSu/Q0H0pylLu9e9BORK91n/kmW7wfkHRnNnIn9IIB8uaI7ElvTg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
     "node_modules/pidtree": {
       "version": "0.6.0",
       "dev": true,
@@ -10459,20 +10490,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
-      "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -15234,7 +15251,9 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.2",
         "es-errors": "^1.3.0",
@@ -15282,7 +15301,9 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21",
     "p-throttle": "^6.1.0",
     "process": "^0.11.10",
-    "qs": "^6.12.3"
+    "picoquery": "^1.4.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
@@ -50,7 +50,6 @@
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^14.0.0",
     "@types/lodash": "^4.17.6",
-    "@types/qs": "^6.9.10",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "@vitest/coverage-v8": "^2.0.2",

--- a/src/create-http-client.ts
+++ b/src/create-http-client.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestHeaders } from 'axios'
 import type { AxiosStatic } from 'axios'
 import copy from 'fast-copy'
-import qs from 'qs'
+import qs from 'picoquery'
 
 import asyncToken from './async-token.js'
 import rateLimitRetry from './rate-limit.js'


### PR DESCRIPTION
Replace qs with picoquery which is faster and much smaller. Fully backwards compatible.

Removes 22 dependencies.