### PR TITLE
fix: DefaultOptions typing was wrong [EXT-6172]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,9 @@ export { default as toPlainObject } from './to-plain-object.js'
 export { default as errorHandler } from './error-handler.js'
 export { default as createDefaultOptions } from './create-default-options.js'
 
-export type { AxiosInstance, CreateHttpClientParams, DefaultOptions } from './types.js'
+export type {
+  AxiosInstance,
+  CreateHttpClientParams,
+  DefaultOptions,
+  InstanceDefaults,
+} from './types.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,15 @@ import type {
   AxiosInstance as OriginalAxiosInstance,
   AxiosRequestConfig,
   AxiosResponse,
+  HeadersDefaults,
 } from 'axios'
 
-export type DefaultOptions = AxiosRequestConfig & {
+export type DefaultOptions = Omit<AxiosRequestConfig, 'headers'> & {
   logHandler: (level: string, data?: Error | string) => void
   responseLogger?: (response: AxiosResponse<any> | Error) => unknown
   requestLogger?: (request: AxiosRequestConfig | Error) => unknown
   retryOnError?: boolean
+  headers: HeadersDefaults
 }
 
 export type AxiosInstance = OriginalAxiosInstance & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type DefaultOptions = Omit<AxiosRequestConfig, 'headers'> & {
   responseLogger?: (response: AxiosResponse<any> | Error) => unknown
   requestLogger?: (request: AxiosRequestConfig | Error) => unknown
   retryOnError?: boolean
-  headers: HeadersDefaults
+  headers: HeadersDefaults & { [key: string]: AxiosHeaderValue }
 }
 
 export type AxiosInstance = OriginalAxiosInstance & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,18 +7,22 @@ import type {
   HeadersDefaults,
 } from 'axios'
 
-export type DefaultOptions = Omit<AxiosRequestConfig, 'headers'> & {
+export type DefaultOptions = AxiosRequestConfig & {
   logHandler: (level: string, data?: Error | string) => void
   responseLogger?: (response: AxiosResponse<any> | Error) => unknown
   requestLogger?: (request: AxiosRequestConfig | Error) => unknown
   retryOnError?: boolean
-  headers: HeadersDefaults & { [key: string]: AxiosHeaderValue }
 }
 
+export type InstanceDefaults = Omit<DefaultOptions, 'headers'> & {
+  headers: HeadersDefaults & {
+    [key: string]: AxiosHeaderValue
+  }
+}
 export type AxiosInstance = OriginalAxiosInstance & {
   httpClientParams: CreateHttpClientParams
   cloneWithNewParams: (params: Partial<CreateHttpClientParams>) => AxiosInstance
-  defaults: DefaultOptions
+  defaults: InstanceDefaults
 }
 
 export type CreateHttpClientParams = {


### PR DESCRIPTION
DefaultOptions typing was wrong. 

AxiosRequestConfig has { headers?: { someHeaderType } }

where AxiosInstance has { headers: { someHeaderType } } // They ensure headers object exist

