### PR TITLE
feat: obscure cross-space headers from response errors

### DIFF
--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -26,7 +26,7 @@ export default function errorHandler(errorResponse: any): never {
   const { config, response } = errorResponse
   let errorName
 
-  obscureHeaders(config);
+  obscureHeaders(config)
 
   if (!isPlainObject(response) || !isPlainObject(config)) {
     throw errorResponse

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,6 +1,19 @@
 import isPlainObject from 'lodash/isPlainObject.js'
 import type { ContentfulErrorData } from './types.js'
 
+function obscureHeaders(config: any) {
+  // Management, Delivery and Preview API tokens
+  if (config?.headers?.['Authorization']) {
+    const token = `...${config.headers['Authorization'].toString().substr(-5)}`
+    config.headers['Authorization'] = `Bearer ${token}`
+  }
+  // Encoded Delivery or Preview token map for Cross-Space References
+  if (config?.headers?.['X-Contentful-Resource-Resolution']) {
+    const token = `...${config.headers['X-Contentful-Resource-Resolution'].toString().substr(-5)}`
+    config.headers['X-Contentful-Resource-Resolution'] = token
+  }
+}
+
 /**
  * Handles errors received from the server. Parses the error into a more useful
  * format, places it in an exception and throws it.
@@ -13,11 +26,7 @@ export default function errorHandler(errorResponse: any): never {
   const { config, response } = errorResponse
   let errorName
 
-  // Obscure the Management token
-  if (config && config.headers && config.headers['Authorization']) {
-    const token = `...${config.headers['Authorization'].toString().substr(-5)}`
-    config.headers['Authorization'] = `Bearer ${token}`
-  }
+  obscureHeaders(config);
 
   if (!isPlainObject(response) || !isPlainObject(config)) {
     throw errorResponse

--- a/test/unit/error-handler-test.spec.ts
+++ b/test/unit/error-handler-test.spec.ts
@@ -104,4 +104,40 @@ describe('A errorHandler', () => {
       expect(err.config.headers.Authorization).toBe('Bearer ...token')
     }
   })
+
+  it('Obscures encoded cross-space reference tokens in any error message', async () => {
+    const responseError: any = cloneDeep(errorMock)
+    responseError.config.headers = {
+      'X-Contentful-Resource-Resolution': 'secret-token',
+    }
+
+    try {
+      errorHandler(responseError)
+    } catch (err: any) {
+      const parsedMessage = JSON.parse(err.message)
+      expect(parsedMessage.request.headers['X-Contentful-Resource-Resolution']).toBe('...token')
+    }
+
+    const requestError: any = {
+      config: {
+        url: 'requesturl',
+        headers: {},
+      },
+      data: {},
+      request: {
+        status: 404,
+        statusText: 'Not Found',
+      },
+    }
+
+    requestError.config.headers = {
+      'X-Contentful-Resource-Resolution': 'secret-token',
+    }
+
+    try {
+      errorHandler(requestError)
+    } catch (err: any) {
+      expect(err.config.headers['X-Contentful-Resource-Resolution']).toBe('...token')
+    }
+  })
 })


### PR DESCRIPTION
With the use of the [extra header for cross-space resolution](https://www.contentful.com/developers/docs/references/content-delivery-api/#extra-header-for-cross-space-resolution), errors include an unobscured encoded token map. This applies the same obscuring technique used for the `Authorization` header to the `X-Contentful-Resource-Resolution` one.


Example:
```json
{
    "status": 404,
    "statusText": "Not Found",
    "message": "The resource could not be found.",
    "details": {
      "type": "Space",
      "id": "J2Lo0Dwdxt"
    },
    "request": {
      "url": "https://preview.contentful.com:443/spaces/J2Lo0Dwdxt/environments/master/entries",
      "headers": {
        "Accept": "application/json, text/plain, */*",
        "Content-Type": "application/vnd.contentful.delivery.v1+json",
        "X-Contentful-Resource-Resolution": "...9fQ==",
        "X-Contentful-User-Agent": "sdk contentful.js/11.5.4; platform node.js/v22.13.1; os macOS/v22.13.1;",
        "Authorization": "Bearer ...i_KuA",
        "User-Agent": "axios/1.8.1",
        "Accept-Encoding": "gzip, compress, deflate, br"
      },
      "method": "get"
    },
    "requestId": "10621051-215d-55cc-87fa-b00d4f550218"
  }
  ```