### PR TITLE
feat: add support for forwarding fetchOptions to axios client

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export type CreateHttpClientParams = {
   adapter?: AxiosRequestConfig['adapter']
   /** Axios proxy config */
   proxy?: AxiosRequestConfig['proxy']
+  /** Axios fetch options */
+  fetchOptions?: AxiosRequestConfig['fetchOptions']
 
   /** Gets called on every request triggered by the SDK, takes the axios request config as an argument */
   requestLogger?: DefaultOptions['requestLogger']

--- a/test/unit/create-http-client-test.spec.ts
+++ b/test/unit/create-http-client-test.spec.ts
@@ -176,3 +176,20 @@ it('Can change the adapter axios uses', () => {
   expect(logHandlerStub).not.toHaveBeenCalled()
   expect(instance.httpClientParams.adapter).toEqual(testAdapter)
 })
+
+it('Can change to the fetch adapter with fetch options', () => {
+  const instance = createHttpClient(axios, {
+    accessToken: 'clientAccessToken',
+    space: 'clientSpaceId',
+    defaultHostname: 'defaulthost',
+    logHandler: logHandlerStub,
+    adapter: 'fetch',
+    fetchOptions: { cache: 'no-cache' },
+  })
+
+  const [callConfig] = vi.mocked(axios.create).mock.calls[0]
+  expect(callConfig?.baseURL).toEqual('https://defaulthost:443/spaces/clientSpaceId/')
+  expect(logHandlerStub).not.toHaveBeenCalled()
+  expect(instance.httpClientParams.adapter).toEqual('fetch')
+  expect(instance.httpClientParams.fetchOptions).toEqual({ cache: 'no-cache' })
+})


### PR DESCRIPTION
As a user of the contentful SDKs, I would like to use axios' `fetch` adapter and fetch options to control [data cache](https://nextjs.org/docs/app/api-reference/functions/fetch) behaviours in nextjs. This is now a solved problem in the axios library itself, and it seems like the only change required in this PR is a modification to the `CreateHttpClientParams` type.