### PR TITLE
fix: forward fetchOptions to axiosOptions

### DIFF
--- a/src/create-default-options.ts
+++ b/src/create-default-options.ts
@@ -83,6 +83,7 @@ export default function createDefaultOptions(options: CreateHttpClientParams): D
     proxy: config.proxy,
     timeout: config.timeout,
     adapter: config.adapter,
+    fetchOptions: config.fetchOptions,
     maxContentLength: config.maxContentLength,
     maxBodyLength: config.maxBodyLength,
     paramsSerializer: {


### PR DESCRIPTION
I was testing the changes merged in https://github.com/contentful/contentful-sdk-core/pull/540, and noticed the fetchOptions were not taking effect. I realised that this was not being passed to the underlying axios options - so a very simple one-line fix 🙏🏼 